### PR TITLE
fix: Used default bold for TabView

### DIFF
--- a/tns-core-modules-widgets/android/widgets/src/main/java/org/nativescript/widgets/TabLayout.java
+++ b/tns-core-modules-widgets/android/widgets/src/main/java/org/nativescript/widgets/TabLayout.java
@@ -250,6 +250,7 @@ public class TabLayout extends HorizontalScrollView {
         textView.setGravity(Gravity.CENTER);
         textView.setMaxWidth((int) (TEXT_MAX_WIDTH * density));
         textView.setTextSize(TypedValue.COMPLEX_UNIT_SP, TAB_VIEW_TEXT_SIZE_SP);
+        textView.setTypeface(Typeface.DEFAULT_BOLD);
         textView.setEllipsize(TextUtils.TruncateAt.END);
         textView.setAllCaps(true);
         textView.setMaxLines(2);


### PR DESCRIPTION
Seems that TabView uses bold text in Tabs in android (test are failing now), so I'm adding it back.