### PR TITLE
Revert "perf(core): avoid setting the same value to view properties (…

### DIFF
--- a/packages/core/ui/styling/style-scope.ts
+++ b/packages/core/ui/styling/style-scope.ts
@@ -721,40 +721,25 @@ export class CssState {
 				cssExpsProperties[property] = value;
 				continue;
 			}
-
-			if (property in oldProperties) {
-				const oldValue = oldProperties[property];
-
-				delete oldProperties[property];
-
-				if (oldValue === value) {
-					// Skip unchanged values
-					continue;
-				}
+			delete oldProperties[property];
+			if (property in oldProperties && oldProperties[property] === value) {
+				// Skip unchanged values
+				continue;
 			}
-
 			if (isCssVariable(property)) {
 				view.style.setScopedCssVariable(property, value);
 				delete newPropertyValues[property];
 				continue;
 			}
-
 			valuesToApply[property] = value;
 		}
-
-		// we need to parse CSS vars first before evaluating css expressions
+		//we need to parse CSS vars first before evaluating css expressions
 		for (const property in cssExpsProperties) {
+			delete oldProperties[property];
 			const value = evaluateCssExpressions(view, property, cssExpsProperties[property]);
-
-			if (property in oldProperties) {
-				const oldValue = oldProperties[property];
-
-				delete oldProperties[property];
-
-				if (oldValue === value) {
-					// Skip unchanged values
-					continue;
-				}
+			if (property in oldProperties && oldProperties[property] === value) {
+				// Skip unchanged values
+				continue;
 			}
 			if (value === unsetValue) {
 				delete newPropertyValues[property];
@@ -776,11 +761,9 @@ export class CssState {
 				view[camelCasedProperty] = unsetValue;
 			}
 		}
-
 		// Set new values to the style
 		for (const property in valuesToApply) {
 			const value = valuesToApply[property];
-
 			try {
 				if (property in view.style) {
 					view.style[`css:${property}`] = value;


### PR DESCRIPTION
…#10602)"

This reverts commit 499fe8dc82db623550a38d3f91eb9f9252304e31.

<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?
<!-- Describe the changes. -->

Fixes/Implements/Closes #[Issue Number].

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->

